### PR TITLE
ensure config entry has the property runtime_data before using it

### DIFF
--- a/custom_components/lifx_ceiling/util.py
+++ b/custom_components/lifx_ceiling/util.py
@@ -45,6 +45,7 @@ def find_lifx_coordinators(hass: HomeAssistant) -> list[LIFXUpdateCoordinator]:
         possible = [
             entry.runtime_data
             for entry in hass.config_entries.async_loaded_entries(LIFX_DOMAIN)
+            if hasattr(entry, "runtime_data")
         ]
 
     coordinators: list[LIFXUpdateCoordinator] = [


### PR DESCRIPTION
This fixed an issue where one config entry of many did not have the `runtime_data` property, causing a runtime error when listing the valid lights.