### PR TITLE
new approach to light on/off brighness tracking, wait for lifx to start

### DIFF
--- a/custom_components/lifx_ceiling/coordinator.py
+++ b/custom_components/lifx_ceiling/coordinator.py
@@ -196,9 +196,7 @@ class LIFXCeilingUpdateCoordinator(DataUpdateCoordinator[list[LIFXCeiling]]):
 
                 # Check virtual on/off state for each light
                 uplight_is_on = self._uplight_is_on.get(mac, device.uplight_is_on)
-                downlight_is_on = self._downlight_is_on.get(
-                    mac, device.downlight_is_on
-                )
+                downlight_is_on = self._downlight_is_on.get(mac, device.downlight_is_on)
 
                 # If both are virtually off, don't change hardware
                 if not uplight_is_on and not downlight_is_on:
@@ -275,10 +273,16 @@ class LIFXCeilingUpdateCoordinator(DataUpdateCoordinator[list[LIFXCeiling]]):
 
     def get_uplight_is_on(self, device: LIFXCeiling) -> bool:
         """Get virtual on/off state for uplight."""
+        # If main light is off, uplight is off regardless of virtual state
+        if device.power_level == 0:
+            return False
         return self._uplight_is_on.get(device.mac_addr, device.uplight_is_on)
 
     def get_downlight_is_on(self, device: LIFXCeiling) -> bool:
         """Get virtual on/off state for downlight."""
+        # If main light is off, downlight is off regardless of virtual state
+        if device.power_level == 0:
+            return False
         return self._downlight_is_on.get(device.mac_addr, device.downlight_is_on)
 
     def get_uplight_color(self, device: LIFXCeiling) -> tuple[int, int, int, int]:

--- a/custom_components/lifx_ceiling/light.py
+++ b/custom_components/lifx_ceiling/light.py
@@ -106,15 +106,16 @@ class LIFXCeilingDownlight(LIFXCeilingEntity, LightEntity):
 
         if not is_on:
             # Light is off - check if this is just a brightness/color adjustment
-            has_turn_on_intent = not kwargs or any(
-                k not in (
-                    ATTR_TRANSITION, "brightness", "brightness_pct",
-                    "hs_color", "color_temp_kelvin", "color_name"
-                )
-                for k in kwargs
+            # (no actual turn-on intent) vs an explicit turn-on request
+            color_brightness_keys = (
+                ATTR_TRANSITION, "brightness", "brightness_pct",
+                "hs_color", "color_temp_kelvin", "color_name"
+            )
+            is_adjustment_only = kwargs and all(
+                k in color_brightness_keys for k in kwargs
             )
 
-            if not has_turn_on_intent and kwargs:
+            if is_adjustment_only:
                 # Just storing brightness/color, not turning on
                 color = hsbk_for_turn_on(stored_color, **kwargs)
                 self.coordinator.set_downlight_color(self._device, color)
@@ -195,15 +196,16 @@ class LIFXCeilingUplight(LIFXCeilingEntity, LightEntity):
 
         if not is_on:
             # Light is off - check if this is just a brightness/color adjustment
-            has_turn_on_intent = not kwargs or any(
-                k not in (
-                    ATTR_TRANSITION, "brightness", "brightness_pct",
-                    "hs_color", "color_temp_kelvin", "color_name"
-                )
-                for k in kwargs
+            # (no actual turn-on intent) vs an explicit turn-on request
+            color_brightness_keys = (
+                ATTR_TRANSITION, "brightness", "brightness_pct",
+                "hs_color", "color_temp_kelvin", "color_name"
+            )
+            is_adjustment_only = kwargs and all(
+                k in color_brightness_keys for k in kwargs
             )
 
-            if not has_turn_on_intent and kwargs:
+            if is_adjustment_only:
                 # Just storing brightness/color, not turning on
                 color = hsbk_for_turn_on(stored_color, **kwargs)
                 self.coordinator.set_uplight_color(self._device, color)

--- a/custom_components/lifx_ceiling/light.py
+++ b/custom_components/lifx_ceiling/light.py
@@ -106,13 +106,19 @@ class LIFXCeilingDownlight(LIFXCeilingEntity, LightEntity):
 
         if not is_on:
             # Light is off - check if this is just a brightness/color adjustment
-            # (no actual turn-on intent) vs an explicit turn-on request
-            color_brightness_keys = (
-                ATTR_TRANSITION, "brightness", "brightness_pct",
-                "hs_color", "color_temp_kelvin", "color_name"
-            )
-            is_adjustment_only = kwargs and all(
-                k in color_brightness_keys for k in kwargs
+            # (no actual turn-on intent) vs an explicit turn-on request.
+            # is_adjustment_only is True when kwargs has values AND all keys are
+            # color/brightness related (no unknown keys that might indicate intent)
+            color_brightness_keys = {
+                ATTR_TRANSITION,
+                "brightness",
+                "brightness_pct",
+                "hs_color",
+                "color_temp_kelvin",
+                "color_name",
+            }
+            is_adjustment_only = bool(
+                kwargs and not any(k not in color_brightness_keys for k in kwargs)
             )
 
             if is_adjustment_only:
@@ -196,13 +202,19 @@ class LIFXCeilingUplight(LIFXCeilingEntity, LightEntity):
 
         if not is_on:
             # Light is off - check if this is just a brightness/color adjustment
-            # (no actual turn-on intent) vs an explicit turn-on request
-            color_brightness_keys = (
-                ATTR_TRANSITION, "brightness", "brightness_pct",
-                "hs_color", "color_temp_kelvin", "color_name"
-            )
-            is_adjustment_only = kwargs and all(
-                k in color_brightness_keys for k in kwargs
+            # (no actual turn-on intent) vs an explicit turn-on request.
+            # is_adjustment_only is True when kwargs has values AND all keys are
+            # color/brightness related (no unknown keys that might indicate intent)
+            color_brightness_keys = {
+                ATTR_TRANSITION,
+                "brightness",
+                "brightness_pct",
+                "hs_color",
+                "color_temp_kelvin",
+                "color_name",
+            }
+            is_adjustment_only = bool(
+                kwargs and not any(k not in color_brightness_keys for k in kwargs)
             )
 
             if is_adjustment_only:

--- a/custom_components/lifx_ceiling/util.py
+++ b/custom_components/lifx_ceiling/util.py
@@ -47,6 +47,10 @@ def find_lifx_coordinators(hass: HomeAssistant) -> list[LIFXUpdateCoordinator]:
         and isinstance(entry.runtime_data, LIFXUpdateCoordinator)
         and entry.runtime_data.is_matrix
         and entry.runtime_data.device.product in LIFX_CEILING_PRODUCT_IDS
+        and hasattr(entry.runtime_data.device, "chain")
+        and entry.runtime_data.device.chain
+        and len(entry.runtime_data.device.chain) > 0
+        and entry.runtime_data.device.chain[0]
     ]
     return coordinators
 


### PR DESCRIPTION
## Summary

This PR implements a new approach to tracking uplight and downlight brightness and on/off states that fixes several critical bugs with the previous implementation. The core change is introducing virtual state tracking in the coordinator to properly handle partial on/off scenarios and brightness adjustments when lights are off.

## Key Changes

### Virtual State Tracking (coordinator.py)
- Added four new dictionaries to track virtual state per device (by MAC address):
  - `_uplight_is_on` / `_downlight_is_on`: Track virtual on/off state
  - `_uplight_color` / `_downlight_color`: Store desired HSBK colors
- State is initialized from hardware on discovery
- New getter/setter methods: `get_uplight_is_on()`, `set_uplight_color()`, etc.
- Virtual state respects main light power level (returns False when main light is off)

### Enhanced Light Entity Behavior (light.py)
- **Brightness/color adjustments when off**: Light entities now distinguish between:
  - Explicit turn-on requests (no kwargs or kwargs with non-color/brightness keys)
  - Brightness/color adjustments (only transition/brightness/color kwargs)
- When off and receiving adjustments, entities store the values without turning on
- Uses stored color as base instead of hardware state for `turn_on()` operations
- Displays stored brightness in UI when light is off (previously showed 0)

### Improved Set State Service (coordinator.py)
- `lifx_ceiling.set_state` now respects virtual on/off state
- Applies zero brightness to zones that are virtually off
- Stores desired colors even when zones are off
- Uses `power_on=False` for set64 operations to avoid unwanted power state changes

### Startup Reliability (__init__.py)
- Added `ConfigEntryNotReady` check to wait for LIFX integration to load ceiling devices
- Prevents race conditions during Home Assistant startup/reboot

### Code Quality
- Converted color values to int explicitly to prevent float/precision issues
- Changed `color_brightness_keys` from tuple to set for more efficient membership testing
- Improved code comments explaining adjustment-only vs turn-on logic

## Bugs Fixed

- ✅ Downlight no longer switches to max brightness when switched back on
- ✅ Changing `uplight_brightness` or `downlight_brightness` when either is off now preserves the value
- ✅ Part light stays off but shows correct brightness when switched on
- ✅ Regular LIFX light entity respects individual zone states when turned off and back on
- ✅ Brightness adjustments while off no longer turn the light on
- ✅ Integration waits for LIFX to start before attempting initialization on reboot

## Testing Performed

- ✅ Change `uplight_brightness` or `downlight_brightness` when either is off → part light stays off but is the correct brightness when switched on
- ✅ Regular LIFX light entity is off when `uplight_brightness` or `downlight_brightness` is changed → stays off but correct brightness when switched on
- ✅ Up or downlight switched off when regular light switched off and on → stays in the appropriate state
- ✅ No longer switches to max brightness when switching the downlight back on
- ✅ Integration properly waits for LIFX to start when rebooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>