### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   hassfest:
     name: "Hassfest Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/Djelibeybi/hass-lifx-ceiling/security/code-scanning/3](https://github.com/Djelibeybi/hass-lifx-ceiling/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/validate.yml` so all jobs inherit least-privilege token access.  
Best single fix (without changing functionality): add:

```yml
permissions:
  contents: read
```

right after the `on:` triggers block (before `jobs:`). This documents intended access and prevents accidental broader token permissions if repo/org defaults change.

No imports, methods, or dependencies are needed—just YAML config update in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permissions configuration to GitHub Actions workflow with read-only access to repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->